### PR TITLE
Update dependencies, switch to syaz0

### DIFF
--- a/eventeditor/ai.py
+++ b/eventeditor/ai.py
@@ -5,7 +5,7 @@ import functools
 import os
 from pathlib import Path
 import typing
-import wszst_yaz0
+import syaz0
 
 _rom_path: typing.Optional[Path] = None
 def set_rom_path(p: typing.Optional[str]) -> None:
@@ -123,8 +123,9 @@ class AIDef:
         if self._ai_defs or not _rom_path:
             return
 
-        raw_data = wszst_yaz0.decompress_file(
-            str(_rom_path / 'Pack/Bootup.pack/Actor/AIDef/AIDef_Game.product.sbyml'))
+        raw_data = syaz0.decompress(
+            (_rom_path / 'Pack/Bootup.pack/Actor/AIDef/AIDef_Game.product.sbyml').read_bytes()
+        )
         defs = byml.Byml(raw_data).parse()
         if isinstance(defs, dict):
             self._ai_defs = defs

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         'evfl~=1.1',
         'pyqt5-sip~=12.7',
-        'pyqtwebengine~=5.14'
+        'pyqtwebengine~=5.14',
         'PyYAML~=5.1',
         'aamp~=1.0',
         'byml~=2.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,15 @@ setuptools.setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     include_package_data=True,
-    install_requires=['evfl~=1.1', 'PyYAML~=5.1', 'aamp~=1.0', 'byml~=2.0', 'wszst_yaz0~=1.1'],
+    install_requires=[
+        'evfl~=1.1',
+        'pyqt5-sip~=12.7',
+        'pyqtwebengine~=5.14'
+        'PyYAML~=5.1',
+        'aamp~=1.0',
+        'byml~=2.0',
+        'syaz0~=1.0.1',
+    ],
     python_requires='>=3.6',
     entry_points={
         'gui_scripts': [


### PR DESCRIPTION
Since people often have trouble running Event Editor on account of the PyQt5 dependency changes, figured it would help to update the dependencies. Switched from `wszst_yaz0` to `syaz0` while at it.