### PR TITLE
Add Linux white screen troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The configuration file is stored:
 
 ### Known issues
 
+* On Linux, if the main window view is a completely blank screen, even after opening a file, try running `QTWEBENGINE_DISABLE_SANDBOX=1 eventeditor` to start the tool.
+
 * Unlinking events while in fork/join will break graph generation most of the time. So using that option is not recommended when fork/join events are involved.
 
 ### What needs to be done


### PR DESCRIPTION
On certain Linux setups, `eventeditor` needs the `QTWEBENGINE_DISABLE_SANDBOX=1` environmental flag to be set in order for the flowchart view to display. This PR adds this information to the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/event-editor/6)
<!-- Reviewable:end -->
