### PR TITLE
Add alternate autofill option for games other than Breath of the Wild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 dist/
 _test.py
 build/
+
+.vscode/
+*.bfevfl

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Install Python 3.6+ (**64 bit version**) and PyQt5, then run `pip install eventeditor`.
 
+### Configuration
+
+The configuration file is stored:
+
+* On Linux or macOS: at `~/.config/eventeditor/eventeditor.ini`
+* On Windows: at `%APPDATA%/eventeditor/eventeditor.ini`
+
 ### Auto completion
 
 In order to enable auto completion for actors, actions and queries, add:
@@ -18,10 +25,20 @@ to EventEditor's configuration file, where `/path/to/game_rom` is a path such th
 An easy, recommended way to get the required file structure without extracting every archive
 is to use [botwfstools](https://github.com/leoetlino/botwfstools).
 
-The configuration file is stored:
+Alternatively, add
+```ini
+[paths]
+json_root=/path/to/folder
+```
+to the configuration folder, where `/path/to/folder` is a path to a folder containing `.json` files named in the format *`<Actor>`*`#`*`<Parameter>`*`.json`. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(by looking at existing event flows)*.
 
-* On Linux or macOS: at `~/.config/eventeditor/eventeditor.ini`
-* On Windows: at `%APPDATA%/eventeditor/eventeditor.ini`
+#### Example JSON
+*`EventActor#Talk.json`*
+```json
+{
+    "IsWaitFinish": false
+}
+```
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -29,39 +29,9 @@ is to use [botwfstools](https://github.com/leoetlino/botwfstools).
 
 #### Other games
 
-Alternatively, add:
+Alternatively, JSON actor definitions can be generated under *Flowchart* > *Export actor definition data to JSON*. This will generate information for auto-completion from the currently open event flow. The first time this is run, a prompt will appear asking for where to save this information.
 
-```ini
-[paths]
-actor_json_root=/path/to/folder
-```
-to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named after each event actor.
-
-This is intended for use where the rom option is not available, and requires manually crafted `.json` files. Currently the program provides some tools that can assist in the generation of these files:
-
-0. Set the `actor_json_root` path in the configuration file
-1. Open an existing event flow and switch to the *Actors* tab
-2. Right-click on an actor > *Export JSON*
-    - Save it in the folder specified in the configuration file
-    - Do not change the filename, as it is used to find the actor when auto-completing
-3. Right-click on an action/query to *Jump to events* that use it 
-4. Right-click on an event > *Edit...* to view parameters and click *Copy JSON*
-    - The parameter values used in the chosen event will be used as default values for auto-completion *(can be manually edited)*
-5. Open the generated `.json` file and replace (paste) the copied action/query
-
-##### Example JSON (formatted)
-```json
-// EventActor.json
-{
-    "actions": {
-        "Talk": {
-            "IsWaitFinish": false
-        }
-    },
-    "queries": {
-    }
-}
-```
+This action can be safely repeated in case other event flows contain actors, actions, or queries that have yet to be included in the JSON file (existing entries will not be overwritten).
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ is to use [botwfstools](https://github.com/leoetlino/botwfstools).
 Alternatively, add
 ```ini
 [paths]
-json_root=/path/to/folder
+actor_json_root=/path/to/folder
 ```
-to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named in the format *`<Actor>`*`#`*`<Parameter>`*`.json`. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(from looking at existing event flows)*.
+to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named after each event actor. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(e.g. from looking at existing event flow(s))*.
 
 #### Example JSON
-*`EventActor#Talk.json`*
+*`EventActor.json`*
 ```json
 {
-    "IsWaitFinish": false
+    "Talk": {
+        "IsWaitFinish": false
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ The configuration file is stored:
 * On Linux or macOS: at `~/.config/eventeditor/eventeditor.ini`
 * On Windows: at `%APPDATA%/eventeditor/eventeditor.ini`
 
-### Auto completion
+### Auto-completion
 
-In order to enable auto completion for actors, actions and queries, add:
+#### Breath of the Wild
+
+In order to enable auto-completion for actors, actions, and queries, add:
 
 ```ini
 [paths]
@@ -25,19 +27,38 @@ to EventEditor's configuration file, where `/path/to/game_rom` is a path such th
 An easy, recommended way to get the required file structure without extracting every archive
 is to use [botwfstools](https://github.com/leoetlino/botwfstools).
 
-Alternatively, add
+#### Other games
+
+Alternatively, add:
+
 ```ini
 [paths]
 actor_json_root=/path/to/folder
 ```
-to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named after each event actor. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(e.g. from looking at existing event flow(s))*.
+to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named after each event actor.
 
-#### Example JSON
-*`EventActor.json`*
+This is intended for use where the rom option is not available, and requires manually crafted `.json` files. Currently the program provides some tools that can assist in the generation of these files:
+
+0. Set the `actor_json_root` path in the configuration file
+1. Open an existing event flow and switch to the *Actors* tab
+2. Right-click on an actor > *Export JSON*
+    - Save it in the folder specified in the configuration file
+    - Do not change the filename, as it is used to find the actor when auto-completing
+3. Right-click on an action/query to *Jump to events* that use it 
+4. Right-click on an event > *Edit...* to view parameters and click *Copy JSON*
+    - The parameter values used in the chosen event will be used as default values for auto-completion *(can be manually edited)*
+5. Open the generated `.json` file and replace (paste) the copied action/query
+
+##### Example JSON (formatted)
 ```json
+// EventActor.json
 {
-    "Talk": {
-        "IsWaitFinish": false
+    "actions": {
+        "Talk": {
+            "IsWaitFinish": false
+        }
+    },
+    "queries": {
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Alternatively, add
 [paths]
 json_root=/path/to/folder
 ```
-to the configuration folder, where `/path/to/folder` is a path to a folder containing `.json` files named in the format *`<Actor>`*`#`*`<Parameter>`*`.json`. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(by looking at existing event flows)*.
+to the configuration file, where `/path/to/folder` is a path to a folder containing `.json` files named in the format *`<Actor>`*`#`*`<Parameter>`*`.json`. This is intended for use where the rom option is not available, and requires manually crafted `.json` files *(from looking at existing event flows)*.
 
 #### Example JSON
 *`EventActor#Talk.json`*

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -9,9 +9,9 @@ import typing
 import evfl
 from evfl import EventFlow
 import eventeditor.ai as ai
+import eventeditor.actor_json as aj
 from eventeditor.actor_view import ActorView
 from eventeditor.event_view import EventView
-import eventeditor.event_edit_dialog as evedit
 from eventeditor.flow_data import FlowData, FlowDataChangeReason
 from eventeditor.flowchart_view import FlowchartView
 import eventeditor.util as util
@@ -181,7 +181,7 @@ class MainWindow(q.QMainWindow):
     def readSettings(self) -> None:
         settings = qc.QSettings()
         ai.set_rom_path(settings.value('paths/rom_root'))
-        evedit.set_actor_json_path(settings.value('paths/actor_json_root'))
+        aj.set_actor_json_path(settings.value('paths/actor_json_root'))
         settings.beginGroup('MainWindow')
         self.resize(settings.value('size', qc.QSize(800, 600)))
         self.move(settings.value('pos', qc.QPoint(200, 200)))

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -204,6 +204,11 @@ class MainWindow(q.QMainWindow):
         settings.setValue('visible_params', self.event_param_visible_action.isChecked())
         settings.endGroup()
 
+        if aj._actor_json_path:
+            settings.beginGroup('paths')
+            settings.setValue('actor_json_root', str(aj._actor_json_path))
+            settings.endGroup()
+
     def updateTitleAndActions(self) -> None:
         if not self.flow:
             self.setWindowTitle('EventEditor')

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -71,7 +71,9 @@ class MainWindow(q.QMainWindow):
         self.save_action.triggered.connect(self.onSaveFile)
 
         self.save_as_action = q.QAction('Save as...', self)
-        self.save_as_action.setShortcut(qg.QKeySequence.SaveAs)
+        # No shortcut is assigned for Windows in QKeySequence.SaveAs
+        # self.save_as_action.setShortcut(qg.QKeySequence.SaveAs)
+        self.save_as_action.setShortcut('Ctrl+Shift+S')
         self.save_as_action.setEnabled(False)
         self.save_as_action.triggered.connect(self.onSaveAsFile)
 

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -11,6 +11,7 @@ from evfl import EventFlow
 import eventeditor.ai as ai
 from eventeditor.actor_view import ActorView
 from eventeditor.event_view import EventView
+import eventeditor.event_edit_dialog as evedit
 from eventeditor.flow_data import FlowData, FlowDataChangeReason
 from eventeditor.flowchart_view import FlowchartView
 import eventeditor.util as util
@@ -180,6 +181,7 @@ class MainWindow(q.QMainWindow):
     def readSettings(self) -> None:
         settings = qc.QSettings()
         ai.set_rom_path(settings.value('paths/rom_root'))
+        evedit.set_json_path(settings.value('paths/json_root'))
         settings.beginGroup('MainWindow')
         self.resize(settings.value('size', qc.QSize(800, 600)))
         self.move(settings.value('pos', qc.QPoint(200, 200)))

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -186,7 +186,7 @@ class MainWindow(q.QMainWindow):
     def readSettings(self) -> None:
         settings = qc.QSettings()
         ai.set_rom_path(settings.value('paths/rom_root'))
-        aj.set_actor_json_path(settings.value('paths/actor_json_root'))
+        aj.set_actor_definitions_path(settings.value('paths/actor_definitions_root'))
         settings.beginGroup('MainWindow')
         self.resize(settings.value('size', qc.QSize(800, 600)))
         self.move(settings.value('pos', qc.QPoint(200, 200)))
@@ -209,9 +209,9 @@ class MainWindow(q.QMainWindow):
         settings.setValue('visible_params', self.event_param_visible_action.isChecked())
         settings.endGroup()
 
-        if aj._actor_json_path:
+        if aj._actor_definitions_path:
             settings.beginGroup('paths')
-            settings.setValue('actor_json_root', str(aj._actor_json_path))
+            settings.setValue('actor_definitions_root', str(aj._actor_definitions_path))
             settings.endGroup()
 
     def updateTitleAndActions(self) -> None:

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -181,7 +181,7 @@ class MainWindow(q.QMainWindow):
     def readSettings(self) -> None:
         settings = qc.QSettings()
         ai.set_rom_path(settings.value('paths/rom_root'))
-        evedit.set_json_path(settings.value('paths/json_root'))
+        evedit.set_actor_json_path(settings.value('paths/actor_json_root'))
         settings.beginGroup('MainWindow')
         self.resize(settings.value('size', qc.QSize(800, 600)))
         self.move(settings.value('pos', qc.QPoint(200, 200)))

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -104,6 +104,8 @@ class MainWindow(q.QMainWindow):
         view_menu.addAction(self.reload_graph_action)
         self.export_graph_action = q.QAction('E&xport graph data to JSON...', self)
         view_menu.addAction(self.export_graph_action)
+        self.export_definitions_action = q.QAction('Ex&port actor definition data to JSON...', self)
+        view_menu.addAction(self.export_definitions_action)
         view_menu.addSeparator()
         self.add_event_action = q.QAction('&Add event...', self)
         view_menu.addAction(self.add_event_action)
@@ -151,6 +153,7 @@ class MainWindow(q.QMainWindow):
         self.flowchart_view.eventSelected.connect(self.onEventSelected)
         self.reload_graph_action.triggered.connect(self.flowchart_view.reload)
         self.export_graph_action.triggered.connect(self.flowchart_view.export)
+        self.export_definitions_action.triggered.connect(self.flowchart_view.export_definitions)
         self.add_event_action.triggered.connect(self.flowchart_view.addNewEvent)
         self.add_fork_action.triggered.connect(self.flowchart_view.addFork)
 

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -1,7 +1,9 @@
 from enum import IntEnum
+import typing
+
 import json
 from pathlib import Path
-import typing
+import PyQt5.QtWidgets as q
 
 _actor_json_path: typing.Optional[Path] = None
 def set_actor_json_path(p: typing.Optional[str]) -> None:
@@ -30,21 +32,40 @@ def load_event_parameters(actor_name: str, event_name: str, event_type: EventTyp
         actor = load_actor_json(actor_name)
 
         if event_type == EventType.Action:
-            return actor["actions"][event_name]
+            return actor['actions'][event_name]
         if event_type == EventType.Query:
-            return actor["queries"][event_name]
+            return actor['queries'][event_name]
         return None
     except:
         return None
 
 def load_actions(actor_name: str) -> typing.KeysView[str]:
     try:
-        return load_actor_json(actor_name)["actions"].keys()
+        return load_actor_json(actor_name)['actions'].keys()
     except:
         return None
 
 def load_queries(actor_name: str) -> typing.KeysView[str]:
     try:
-        return load_actor_json(actor_name)["queries"].keys()
+        return load_actor_json(actor_name)['queries'].keys()
     except:
         return None
+
+def export_actor_json(actor_name: str, actions, queries, window) -> None:
+    # Should open existing file and insert/replace actor entry?
+
+    data = dict()
+    data['actions'] = {}
+    data['queries'] = {}
+    # Also support actor parameters?
+
+    for action in actions:
+        data['actions'][action.v] = {}
+    for query in queries:
+        data['queries'][query.v] = {}
+
+    folder = str(_actor_json_path) if _actor_json_path else ''
+    path = q.QFileDialog.getSaveFileName(window, 'Export as...',  folder, 'JSON (*.json)')[0]
+    with open(path, 'wt') as file:
+        json.dump(data, file)
+    file.close()

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -51,7 +51,7 @@ def load_queries(actor_name: str) -> typing.KeysView[str]:
     except:
         return None
 
-def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], window) -> None:
+def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], parent: typing.Optional[QWidget]) -> None:
     # Should open existing file and insert/replace actor entry?
 
     data = dict()
@@ -65,7 +65,7 @@ def export_actor_json(actor_name: str, actions: typing.List[str], queries: typin
         data['queries'][query] = {}
 
     filename = str(_actor_json_path/f'{actor_name}') if _actor_json_path else actor_name
-    path = q.QFileDialog.getSaveFileName(window, 'Export as...',  filename, 'JSON (*.json)')[0]
+    path = q.QFileDialog.getSaveFileName(parent, 'Export as...',  filename, 'JSON (*.json)')[0]
 
     if not path:
         return

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -20,7 +20,7 @@ def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
         return None
 
     try:
-        # First look for individual actor file
+        # First look for individual actor file (overrides)
         with open(_actor_json_path.parent/f'{actor_name}.json', 'rt') as file:
             return json.loads(file.read())
     except:
@@ -55,6 +55,7 @@ def load_queries(actor_name: str) -> typing.KeysView[str]:
     except:
         return None
 
+#! Replace with 'export all actors' menu option
 def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], widget) -> None:
     if not _actor_json_path:
         set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Set ',  'actor_definitions', 'JSON (*.json)')[0])
@@ -69,15 +70,18 @@ def export_actor_json(actor_name: str, actions: typing.List[str], queries: typin
         definitions = dict()
 
     with open(_actor_json_path, 'wt') as file:
-        # Will replace existing entry, user should be prompted
+        #! Will replace existing entry, user should be prompted
         definitions[actor_name] = {}
         definitions[actor_name]['actions'] = {}
         definitions[actor_name]['queries'] = {}
-        # Also support actor parameters?
+        #! Also support actor parameters?
+        # - currently no auto-complete option at all?
 
         for action in actions:
             definitions[actor_name]['actions'][action] = {}
+            #! Somehow find event and populate with sample parameters
         for query in queries:
             definitions[actor_name]['queries'][query] = {}
+            #! Somehow find event and populate with sample parameters
 
         json.dump(definitions, file)

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -5,28 +5,28 @@ import json
 from pathlib import Path
 import PyQt5.QtWidgets as q
 
-_actor_json_path: typing.Optional[Path] = None
-def set_actor_json_path(p: typing.Optional[str]) -> None:
+_actor_definitions_path: typing.Optional[Path] = None
+def set_actor_definitions_path(p: typing.Optional[str]) -> None:
     if p:
-        global _actor_json_path
-        _actor_json_path = Path(p)
+        global _actor_definitions_path
+        _actor_definitions_path = Path(p)
 
 class EventType(IntEnum):
     Action = 0
     Query = 1
 
 def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
-    if not _actor_json_path:
+    if not _actor_definitions_path:
         return None
 
     try:
         # First look for individual actor file (overrides; for power users)
-        with open(_actor_json_path.parent/f'{actor_name}.json', 'rt') as file:
+        with open(_actor_definitions_path.parent/f'{actor_name}.json', 'rt') as file:
             return json.loads(file.read())
     except:
         try:
             # Otherwise look in actor definitions file
-            with open(_actor_json_path, 'rt') as file:
+            with open(_actor_definitions_path, 'rt') as file:
                 return json.loads(file.read())[actor_name]
         except:
             return None
@@ -60,14 +60,14 @@ def export_definitions(flow, widget) -> None:
         q.QMessageBox.information(widget, 'Export actor definition data', 'Open an event flow first')
         return
 
-    if not _actor_json_path:
-        set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Export actor definitions to...',  'actor_definitions', 'JSON (*.json)')[0])
+    if not _actor_definitions_path:
+        set_actor_definitions_path(q.QFileDialog.getSaveFileName(widget, 'Export actor definitions to...',  'actor_definitions', 'JSON (*.json)')[0])
 
-    if not _actor_json_path:
+    if not _actor_definitions_path:
         return
 
     try:
-        with open(_actor_json_path, 'rt') as file:
+        with open(_actor_definitions_path, 'rt') as file:
             definitions = json.loads(file.read())
     except:
         definitions = dict()
@@ -117,5 +117,5 @@ def export_definitions(flow, widget) -> None:
             if param not in json_parent[event_key]:
                 json_parent[event_key][param] = event.data.params.data[param]
     
-    with open(_actor_json_path, 'wt') as file:
+    with open(_actor_definitions_path, 'wt') as file:
         json.dump(definitions, file)

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
 import typing
 
+from evfl import EventFlow
 from evfl.event import ActionEvent, SwitchEvent
 import json
 from pathlib import Path
@@ -16,7 +17,7 @@ class EventType(IntEnum):
     Action = 0
     Query = 1
 
-def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
+def load_actor_json(actor_name: str) -> typing.Optional[typing.Dict[str, typing.Any]]:
     if not _actor_definitions_path:
         return None
 
@@ -32,7 +33,7 @@ def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
         except:
             return None
 
-def load_event_parameters(actor_name: str, event_name: str, event_type: EventType) -> typing.Dict[str, typing.Any]:
+def load_event_parameters(actor_name: str, event_name: str, event_type: EventType) -> typing.Optional[typing.Dict[str, typing.Any]]:
     try:
         actor = load_actor_json(actor_name)
 
@@ -44,19 +45,19 @@ def load_event_parameters(actor_name: str, event_name: str, event_type: EventTyp
     except:
         return None
 
-def load_actions(actor_name: str) -> typing.Iterable[str]:
+def load_actions(actor_name: str) -> typing.Optional[typing.Iterable[str]]:
     try:
         return load_actor_json(actor_name)['actions'].keys()
     except:
         return None
 
-def load_queries(actor_name: str) -> typing.Iterable[str]:
+def load_queries(actor_name: str) -> typing.Optional[typing.Iterable[str]]:
     try:
         return load_actor_json(actor_name)['queries'].keys()
     except:
         return None
 
-def export_definitions(flow, widget) -> None:
+def export_definitions(flow: typing.Optional[EventFlow], widget: typing.Optional['QWidget']) -> None:
     if not flow:
         q.QMessageBox.information(widget, 'Export actor definition data', 'Open an event flow first')
         return

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -36,3 +36,15 @@ def load_event_parameters(actor_name: str, event_name: str, event_type: EventTyp
         return None
     except:
         return None
+
+def load_actions(actor_name: str) -> typing.KeysView[str]:
+    try:
+        return load_actor_json(actor_name)["actions"].keys()
+    except:
+        return None
+
+def load_queries(actor_name: str) -> typing.KeysView[str]:
+    try:
+        return load_actor_json(actor_name)["queries"].keys()
+    except:
+        return None

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -24,12 +24,12 @@ def load_actor_json(actor_name: str) -> typing.Optional[typing.Dict[str, typing.
     try:
         # First look for individual actor file (overrides; for power users)
         with open(_actor_definitions_path.parent/f'{actor_name}.json', 'rt') as file:
-            return json.loads(file.read())
+            return json.load(file)
     except:
         try:
             # Otherwise look in actor definitions file
             with open(_actor_definitions_path, 'rt') as file:
-                return json.loads(file.read())[actor_name]
+                return json.load(file)[actor_name]
         except:
             return None
 

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -20,12 +20,16 @@ def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
         return None
 
     try:
-        # Try loading from a single file with all actors first
-        # before looking for individual actor files?
-        with open(_actor_json_path/f'{actor_name}.json', 'rt') as stream:
-            return json.loads(stream.read())
+        # First look for individual actor file
+        with open(_actor_json_path.parent/f'{actor_name}.json', 'rt') as file:
+            return json.loads(file.read())
     except:
-        return None
+        try:
+            # Otherwise look in actor definitions file
+            with open(_actor_json_path, 'rt') as file:
+                return json.loads(file.read())[actor_name]
+        except:
+            return None
 
 def load_event_parameters(actor_name: str, event_name: str, event_type: EventType) -> typing.Dict[str, typing.Any]:
     try:

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -20,7 +20,7 @@ def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
         return None
 
     try:
-        # First look for individual actor file (overrides)
+        # First look for individual actor file (overrides; for power users)
         with open(_actor_json_path.parent/f'{actor_name}.json', 'rt') as file:
             return json.loads(file.read())
     except:
@@ -113,7 +113,7 @@ def export_definitions(flow, widget) -> None:
             continue
         for param in event.data.params.data:
             # Only populate, never overwrite
-            # Power-users can manually edit the json file (or use the copy parameters button)
+            # Power users can manually edit the json file (or use the copy parameters button)
             if param not in json_parent[event_key]:
                 json_parent[event_key][param] = event.data.params.data[param]
     

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -64,8 +64,12 @@ def export_actor_json(actor_name: str, actions, queries, window) -> None:
     for query in queries:
         data['queries'][query.v] = {}
 
-    folder = str(_actor_json_path) if _actor_json_path else ''
-    path = q.QFileDialog.getSaveFileName(window, 'Export as...',  folder, 'JSON (*.json)')[0]
+    filename = str(_actor_json_path/f'{actor_name}') if _actor_json_path else actor_name
+    path = q.QFileDialog.getSaveFileName(window, 'Export as...',  filename, 'JSON (*.json)')[0]
+
+    if not path:
+        return
+
     with open(path, 'wt') as file:
         json.dump(data, file)
     file.close()

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -55,33 +55,46 @@ def load_queries(actor_name: str) -> typing.KeysView[str]:
     except:
         return None
 
-#! Replace with 'export all actors' menu option
-def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], widget) -> None:
-    if not _actor_json_path:
-        set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Set ',  'actor_definitions', 'JSON (*.json)')[0])
-
-    if not _actor_json_path:
+def export_definitions(flow, widget) -> None:
+    if not flow:
+        q.QMessageBox.information(widget, 'Export actor definition data', 'Open an event flow first')
         return
-    
+
+    # if not _actor_json_path:
+    #     set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Set ',  'actor_definitions', 'JSON (*.json)')[0])
+
+    # if not _actor_json_path:
+    #     return
+
     try:
         with open(_actor_json_path, 'rt') as file:
             definitions = json.loads(file.read())
     except:
         definitions = dict()
+    
+    for actor in flow.flowchart.actors:
+        if actor.identifier.name not in definitions:
+            definitions[actor.identifier.name] = {}
 
-    with open(_actor_json_path, 'wt') as file:
-        #! Will replace existing entry, user should be prompted
-        definitions[actor_name] = {}
-        definitions[actor_name]['actions'] = {}
-        definitions[actor_name]['queries'] = {}
+        if 'actions' not in definitions[actor.identifier.name]:
+            definitions[actor.identifier.name]['actions'] = {}        
+        for action in actor.actions:
+            if action.v not in definitions[actor.identifier.name]['actions']:
+                definitions[actor.identifier.name]['actions'][action.v] = {}
+            # Populate/overwrite event parameters?
+
+        if 'queries' not in definitions[actor.identifier.name]:
+            definitions[actor.identifier.name]['queries'] = {}
+        for query in actor.queries:
+            if query.v not in definitions[actor.identifier.name]['queries']:
+                definitions[actor.identifier.name]['queries'][query.v] = {}
+            # Populate/overwrite event parameters?
+        
         #! Also support actor parameters?
-        # - currently no auto-complete option at all?
+        #   - currently no auto-complete option at all?
+    
+    # with open(_actor_json_path, 'wt') as file:
+    #     json.dump(definitions, file)
 
-        for action in actions:
-            definitions[actor_name]['actions'][action] = {}
-            #! Somehow find event and populate with sample parameters
-        for query in queries:
-            definitions[actor_name]['queries'][query] = {}
-            #! Somehow find event and populate with sample parameters
-
-        json.dump(definitions, file)
+    #! For development
+    q.QApplication.clipboard().setText(json.dumps(definitions))

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -112,9 +112,8 @@ def export_definitions(flow: typing.Optional[EventFlow], widget: typing.Optional
 
 def export_actor_classes(actor: typing.Dict[str, typing.Any], category: str, classes: typing.List['StringHolder']) -> None:
     category_root = actor.get(category, {})
-    
+    actor[category] = category_root
+
     for c in classes:
         if c.v not in category_root:
             category_root[c.v] = {}
-    
-    actor[category] = category_root

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -51,25 +51,29 @@ def load_queries(actor_name: str) -> typing.KeysView[str]:
     except:
         return None
 
-def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], parent: typing.Optional[QWidget]) -> None:
-    # Should open existing file and insert/replace actor entry?
+def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], widget) -> None:
+    if not _actor_json_path:
+        set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Set ',  'actor_definitions', 'JSON (*.json)')[0])
 
-    data = dict()
-    data['actions'] = {}
-    data['queries'] = {}
-    # Also support actor parameters?
-
-    for action in actions:
-        data['actions'][action] = {}
-    for query in queries:
-        data['queries'][query] = {}
-
-    filename = str(_actor_json_path/f'{actor_name}') if _actor_json_path else actor_name
-    path = q.QFileDialog.getSaveFileName(parent, 'Export as...',  filename, 'JSON (*.json)')[0]
-
-    if not path:
+    if not _actor_json_path:
         return
+    
+    try:
+        with open(_actor_json_path, 'rt') as file:
+            definitions = json.loads(file.read())
+    except:
+        definitions = dict()
 
-    with open(path, 'wt') as file:
-        json.dump(data, file)
-    file.close()
+    with open(_actor_json_path, 'wt') as file:
+        # Will replace existing entry, user should be prompted
+        definitions[actor_name] = {}
+        definitions[actor_name]['actions'] = {}
+        definitions[actor_name]['queries'] = {}
+        # Also support actor parameters?
+
+        for action in actions:
+            definitions[actor_name]['actions'][action] = {}
+        for query in queries:
+            definitions[actor_name]['queries'][query] = {}
+
+        json.dump(definitions, file)

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -1,0 +1,38 @@
+from enum import IntEnum
+import json
+from pathlib import Path
+import typing
+
+_actor_json_path: typing.Optional[Path] = None
+def set_actor_json_path(p: typing.Optional[str]) -> None:
+    if p:
+        global _actor_json_path
+        _actor_json_path = Path(p)
+
+class EventType(IntEnum):
+    Action = 0
+    Query = 1
+
+def load_actor_json(actor_name: str) -> dict:
+    if not _actor_json_path:
+        return False
+
+    try:
+        # Try loading from a single file with all actors first
+        # before looking for individual actor files?
+        with open(_actor_json_path/f'{actor_name}.json', 'rt') as stream:
+            return json.loads(stream.read())
+    except:
+        return None
+
+def load_event_parameters(actor_name: str, event_name: str, event_type: EventType) -> typing.Dict[str, typing.Any]:
+    try:
+        actor = load_actor_json(actor_name)
+
+        if event_type == EventType.Action:
+            return actor["actions"][event_name]
+        if event_type == EventType.Query:
+            return actor["queries"][event_name]
+        return None
+    except:
+        return None

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
 import typing
 
+from evfl.event import ActionEvent, SwitchEvent
 import json
 from pathlib import Path
 import PyQt5.QtWidgets as q
@@ -88,15 +89,13 @@ def export_definitions(flow, widget) -> None:
             if query.v not in definitions[actor.identifier.name]['queries']:
                 definitions[actor.identifier.name]['queries'][query.v] = {}
         
-        #! Should actor parameters also be supported?
-        #   - currently no auto-complete option at all?
-    
-    #! Should exporting be restructured to only loop through the events?
+        #! Potential future addition: support actor parameters + autofill
+
     for event in flow.flowchart.events:
-        if hasattr(event.data, 'actor_action'):
+        if isinstance(event.data, ActionEvent):
             json_parent = definitions[event.data.actor.v.identifier.name]['actions']
             event_key = event.data.actor_action.v.v
-        elif hasattr(event.data, 'actor_query'):
+        elif isinstance(event.data, SwitchEvent):
             json_parent = definitions[event.data.actor.v.identifier.name]['queries']
             event_key = event.data.actor_query.v.v
         else:

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -15,9 +15,9 @@ class EventType(IntEnum):
     Action = 0
     Query = 1
 
-def load_actor_json(actor_name: str) -> dict:
+def load_actor_json(actor_name: str) -> typing.Dict[str, typing.Any]:
     if not _actor_json_path:
-        return False
+        return None
 
     try:
         # Try loading from a single file with all actors first
@@ -51,7 +51,7 @@ def load_queries(actor_name: str) -> typing.KeysView[str]:
     except:
         return None
 
-def export_actor_json(actor_name: str, actions, queries, window) -> None:
+def export_actor_json(actor_name: str, actions: typing.List[str], queries: typing.List[str], window) -> None:
     # Should open existing file and insert/replace actor entry?
 
     data = dict()
@@ -60,9 +60,9 @@ def export_actor_json(actor_name: str, actions, queries, window) -> None:
     # Also support actor parameters?
 
     for action in actions:
-        data['actions'][action.v] = {}
+        data['actions'][action] = {}
     for query in queries:
-        data['queries'][query.v] = {}
+        data['queries'][query] = {}
 
     filename = str(_actor_json_path/f'{actor_name}') if _actor_json_path else actor_name
     path = q.QFileDialog.getSaveFileName(window, 'Export as...',  filename, 'JSON (*.json)')[0]

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -43,13 +43,13 @@ def load_event_parameters(actor_name: str, event_name: str, event_type: EventTyp
     except:
         return None
 
-def load_actions(actor_name: str) -> typing.KeysView[str]:
+def load_actions(actor_name: str) -> typing.Iterable[str]:
     try:
         return load_actor_json(actor_name)['actions'].keys()
     except:
         return None
 
-def load_queries(actor_name: str) -> typing.KeysView[str]:
+def load_queries(actor_name: str) -> typing.Iterable[str]:
     try:
         return load_actor_json(actor_name)['queries'].keys()
     except:
@@ -61,7 +61,7 @@ def export_definitions(flow, widget) -> None:
         return
 
     if not _actor_json_path:
-        set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Set ',  'actor_definitions', 'JSON (*.json)')[0])
+        set_actor_json_path(q.QFileDialog.getSaveFileName(widget, 'Export actor definitions to...',  'actor_definitions', 'JSON (*.json)')[0])
 
     if not _actor_json_path:
         return

--- a/eventeditor/actor_string_list_view.py
+++ b/eventeditor/actor_string_list_view.py
@@ -1,6 +1,7 @@
 import typing
 
 import eventeditor.ai as ai
+import eventeditor.actor_json as aj
 import eventeditor.util as util
 from eventeditor.search_bar import SearchBar
 from evfl import EventFlow, Actor
@@ -135,8 +136,16 @@ class ActorActionListView(ActorStringListView):
         if not self.actor:
             return ''
         name = self.actor.identifier.name
+
+        actions = []
         aiprog = ai.load_aiprog(name)
-        actions = list(aiprog.actions.keys()) if aiprog else []
+        if aiprog:
+            actions = list(aiprog.actions.keys())
+        else:
+            json_actions = aj.load_actions(name)
+            if json_actions:
+                actions = list(json_actions)
+
         add_dialog = ActorAIClassAddDialog(self, qc.QStringListModel(actions, self))
         add_dialog.setWindowTitle(f'Add an action for {name}')
         ret = add_dialog.exec_()
@@ -154,8 +163,16 @@ class ActorQueryListView(ActorStringListView):
         if not self.actor:
             return ''
         name = self.actor.identifier.name
+
+        queries = []
         aiprog = ai.load_aiprog(name)
-        queries = list(aiprog.queries.keys()) if aiprog else []
+        if aiprog:
+            queries = list(aiprog.queries.keys())
+        else:
+            json_queries = aj.load_queries(name)
+            if json_queries:
+                queries = list(json_actions)
+
         add_dialog = ActorAIClassAddDialog(self, qc.QStringListModel(queries, self))
         add_dialog.setWindowTitle(f'Add a query for {name}')
         ret = add_dialog.exec_()

--- a/eventeditor/actor_string_list_view.py
+++ b/eventeditor/actor_string_list_view.py
@@ -171,7 +171,7 @@ class ActorQueryListView(ActorStringListView):
         else:
             json_queries = aj.load_queries(name)
             if json_queries:
-                queries = list(json_actions)
+                queries = list(json_queries)
 
         add_dialog = ActorAIClassAddDialog(self, qc.QStringListModel(queries, self))
         add_dialog.setWindowTitle(f'Add a query for {name}')

--- a/eventeditor/actor_view.py
+++ b/eventeditor/actor_view.py
@@ -241,7 +241,7 @@ class ActorView(q.QWidget):
     
     def exportActor(self, idx: qc.QModelIndex) -> None:
         actor = idx.data(qc.Qt.UserRole)
-        json = aj.export_actor_json(actor.identifier, actor.actions, actor.queries, self)
+        json = aj.export_actor_json(actor.identifier.name, actor.actions, actor.queries, self)
 
     def hideActorDetailPane(self) -> None:
         self.detail_pane.setActor(None)

--- a/eventeditor/actor_view.py
+++ b/eventeditor/actor_view.py
@@ -1,6 +1,7 @@
 from enum import IntEnum, auto
 import typing
 
+import eventeditor.actor_json as aj
 from eventeditor.actor_model import ActorModelColumn
 from eventeditor.actor_string_list_model import ActorStringListModel
 from eventeditor.actor_string_list_view import ActorActionListView, ActorQueryListView
@@ -237,6 +238,10 @@ class ActorView(q.QWidget):
             return
 
         self.flow_data.actor_model.remove(actor)
+    
+    def exportActor(self, idx: qc.QModelIndex) -> None:
+        actor = idx.data(qc.Qt.UserRole)
+        json = aj.export_actor_json(actor.identifier, actor.actions, actor.queries, self)
 
     def hideActorDetailPane(self) -> None:
         self.detail_pane.setActor(None)
@@ -264,5 +269,6 @@ class ActorView(q.QWidget):
         menu = q.QMenu()
         menu.addAction('&Edit...', lambda: self.editActor(idx))
         menu.addAction('&Remove', lambda: self.removeActor(idx))
+        menu.addAction('&Export JSON', lambda: self.exportActor(idx))
         menu.addAction('&Jump to events', lambda: self.jumpToActorEventsRequested.emit(str(idx.data(qc.Qt.UserRole).identifier) + '::'))
         menu.exec_(self.sender().viewport().mapToGlobal(pos))

--- a/eventeditor/actor_view.py
+++ b/eventeditor/actor_view.py
@@ -1,7 +1,6 @@
 from enum import IntEnum, auto
 import typing
 
-import eventeditor.actor_json as aj
 from eventeditor.actor_model import ActorModelColumn
 from eventeditor.actor_string_list_model import ActorStringListModel
 from eventeditor.actor_string_list_view import ActorActionListView, ActorQueryListView
@@ -238,12 +237,6 @@ class ActorView(q.QWidget):
             return
 
         self.flow_data.actor_model.remove(actor)
-    
-    def exportActor(self, idx: qc.QModelIndex) -> None:
-        actor = idx.data(qc.Qt.UserRole)
-        actions = [action.v for action in actor.actions]
-        queries = [query.v for query in actor.queries]
-        aj.export_actor_json(actor.identifier.name, actions, queries, self)
 
     def hideActorDetailPane(self) -> None:
         self.detail_pane.setActor(None)
@@ -271,6 +264,5 @@ class ActorView(q.QWidget):
         menu = q.QMenu()
         menu.addAction('&Edit...', lambda: self.editActor(idx))
         menu.addAction('&Remove', lambda: self.removeActor(idx))
-        menu.addAction('&Export JSON', lambda: self.exportActor(idx))
         menu.addAction('&Jump to events', lambda: self.jumpToActorEventsRequested.emit(str(idx.data(qc.Qt.UserRole).identifier) + '::'))
         menu.exec_(self.sender().viewport().mapToGlobal(pos))

--- a/eventeditor/actor_view.py
+++ b/eventeditor/actor_view.py
@@ -241,7 +241,9 @@ class ActorView(q.QWidget):
     
     def exportActor(self, idx: qc.QModelIndex) -> None:
         actor = idx.data(qc.Qt.UserRole)
-        json = aj.export_actor_json(actor.identifier.name, actor.actions, actor.queries, self)
+        actions = [action.v for action in actor.actions]
+        queries = [query.v for query in actor.queries]
+        aj.export_actor_json(actor.identifier.name, actions, queries, self)
 
     def hideActorDetailPane(self) -> None:
         self.detail_pane.setActor(None)

--- a/eventeditor/container_view.py
+++ b/eventeditor/container_view.py
@@ -145,6 +145,7 @@ class ContainerAddItemDialog(q.QDialog):
 
 class ContainerView(q.QWidget):
     autofillRequested = qc.pyqtSignal()
+    copyJsonRequested = qc.pyqtSignal()
 
     def __init__(self, parent, model: ContainerModel, flow_data, has_autofill_btn=False) -> None:
         super().__init__(parent)
@@ -174,11 +175,15 @@ class ContainerView(q.QWidget):
         self.autofill_btn = q.QPushButton('Auto fill')
         self.autofill_btn.setStyleSheet('padding: 2px 5px;')
         self.autofill_btn.clicked.connect(self.autofillRequested)
+        self.copy_btn = q.QPushButton('Copy JSON')
+        self.copy_btn.setStyleSheet('padding: 2px 5px;')
+        self.copy_btn.clicked.connect(self.copyJsonRequested)
         box = q.QHBoxLayout()
         label = q.QLabel('Parameters')
         label.setStyleSheet('font-weight: bold;')
         box.addWidget(label, stretch=1)
         if has_autofill_btn:
+            box.addWidget(self.copy_btn)
             box.addWidget(self.autofill_btn)
         box.addWidget(self.add_btn)
 

--- a/eventeditor/container_view.py
+++ b/eventeditor/container_view.py
@@ -146,6 +146,7 @@ class ContainerAddItemDialog(q.QDialog):
 class ContainerView(q.QWidget):
     autofillRequested = qc.pyqtSignal()
     copyJsonRequested = qc.pyqtSignal()
+    pasteJsonRequested = qc.pyqtSignal()
 
     def __init__(self, parent, model: ContainerModel, flow_data, has_autofill_btn=False) -> None:
         super().__init__(parent)
@@ -178,12 +179,16 @@ class ContainerView(q.QWidget):
         self.copy_btn = q.QPushButton('Copy JSON')
         self.copy_btn.setStyleSheet('padding: 2px 5px;')
         self.copy_btn.clicked.connect(self.copyJsonRequested)
+        self.paste_btn = q.QPushButton('Paste JSON')
+        self.paste_btn.setStyleSheet('padding: 2px 5px;')
+        self.paste_btn.clicked.connect(self.pasteJsonRequested)
         box = q.QHBoxLayout()
         label = q.QLabel('Parameters')
         label.setStyleSheet('font-weight: bold;')
         box.addWidget(label, stretch=1)
         if has_autofill_btn:
             box.addWidget(self.copy_btn)
+            box.addWidget(self.paste_btn)
             box.addWidget(self.autofill_btn)
         box.addWidget(self.add_btn)
 

--- a/eventeditor/event_edit_dialog.py
+++ b/eventeditor/event_edit_dialog.py
@@ -154,16 +154,14 @@ class ActorRelatedEventEditDialog(q.QDialog):
     def onPasteJsonRequested(self) -> None:
         try:
             data = json.loads(f'{{{q.QApplication.clipboard().text()}}}')
-            # if str(self.attr_cbox.currentData().v) not in data:
-                # Prompt user if still want to paste?
-                # May need deeper error-checking
             params = data[self.attr_cbox.currentData().v]
             self.modified_params.data.clear()
             for param in params:
                 self.modified_params.data[param] = params[param]
             self.param_model.set(self.modified_params)
 
-        except Exception as e: print(e)
+        except:
+            q.QMessageBox.critical(self, 'Paste JSON', 'Failed to paste clipboard data as parameters.')
 
     def onActorSelected(self, actor_idx: int) -> None:
         if actor_idx == -1:

--- a/eventeditor/event_edit_dialog.py
+++ b/eventeditor/event_edit_dialog.py
@@ -132,7 +132,7 @@ class ActorRelatedEventEditDialog(q.QDialog):
 
             self.modified_params.data.clear()
             for param in parameters:
-                self.modified_params.data[param] = parameter[param]
+                self.modified_params.data[param] = parameters[param]
             self.param_model.set(self.modified_params)
 
             return True

--- a/eventeditor/event_edit_dialog.py
+++ b/eventeditor/event_edit_dialog.py
@@ -127,9 +127,7 @@ class ActorRelatedEventEditDialog(q.QDialog):
             parameters = aj.load_event_parameters(actor_name, attr_name, event_type)
 
             if parameters is None:
-                q.QMessageBox.critical(self, 'Cannot auto fill', 'The selected action/query is not registered in the JSON fallback.')
-                # Didn't actually succeed but return True to not replace aiprog load error
-                return True
+                return False
 
             self.modified_params.data.clear()
             for key, value in parameters.items():

--- a/eventeditor/event_edit_dialog.py
+++ b/eventeditor/event_edit_dialog.py
@@ -86,6 +86,7 @@ class ActorRelatedEventEditDialog(q.QDialog):
         self.param_view = ContainerView(None, self.param_model, self.flow_data, has_autofill_btn=True)
         self.param_view.autofillRequested.connect(self.onAutofillRequested)
         self.param_view.copyJsonRequested.connect(self.onCopyJsonRequested)
+        self.param_view.pasteJsonRequested.connect(self.onPasteJsonRequested)
 
     def onAutofillRequested(self) -> None:
         new_actor: Actor = self.actor_cbox.currentData()
@@ -130,8 +131,8 @@ class ActorRelatedEventEditDialog(q.QDialog):
                 return False
 
             self.modified_params.data.clear()
-            for key, value in parameters.items():
-                self.modified_params.data[key] = value
+            for param in parameters:
+                self.modified_params.data[param] = parameter[param]
             self.param_model.set(self.modified_params)
 
             return True
@@ -149,6 +150,20 @@ class ActorRelatedEventEditDialog(q.QDialog):
             toClipboard = json.dumps(params)[1:-1]
 
         q.QApplication.clipboard().setText(toClipboard)
+    
+    def onPasteJsonRequested(self) -> None:
+        try:
+            data = json.loads(f'{{{q.QApplication.clipboard().text()}}}')
+            # if str(self.attr_cbox.currentData().v) not in data:
+                # Prompt user if still want to paste?
+                # May need deeper error-checking
+            params = data[self.attr_cbox.currentData().v]
+            self.modified_params.data.clear()
+            for param in params:
+                self.modified_params.data[param] = params[param]
+            self.param_model.set(self.modified_params)
+
+        except Exception as e: print(e)
 
     def onActorSelected(self, actor_idx: int) -> None:
         if actor_idx == -1:

--- a/eventeditor/event_edit_dialog.py
+++ b/eventeditor/event_edit_dialog.py
@@ -11,6 +11,7 @@ import eventeditor.util as util
 from evfl import Container, Actor, Event
 from evfl.enums import EventType
 import evfl.event
+import json
 import PyQt5.QtCore as qc # type: ignore
 import PyQt5.QtGui as qg # type: ignore
 import PyQt5.QtWidgets as q # type: ignore
@@ -84,6 +85,7 @@ class ActorRelatedEventEditDialog(q.QDialog):
     def createParametersView(self) -> None:
         self.param_view = ContainerView(None, self.param_model, self.flow_data, has_autofill_btn=True)
         self.param_view.autofillRequested.connect(self.onAutofillRequested)
+        self.param_view.copyJsonRequested.connect(self.onCopyJsonRequested)
 
     def onAutofillRequested(self) -> None:
         new_actor: Actor = self.actor_cbox.currentData()
@@ -138,6 +140,17 @@ class ActorRelatedEventEditDialog(q.QDialog):
 
         except:
             return False
+    
+    def onCopyJsonRequested(self) -> None:
+        toClipboard = json.dumps(self.modified_params.data)
+
+        if self.attr_cbox.currentData():
+            params = dict()
+            params[str(self.attr_cbox.currentData().v)] = self.modified_params.data
+            # Remove outer curly brackets for convenience
+            toClipboard = json.dumps(params)[1:-1]
+
+        q.QApplication.clipboard().setText(toClipboard)
 
     def onActorSelected(self, actor_idx: int) -> None:
         if actor_idx == -1:

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -207,10 +207,8 @@ class FlowchartView(q.QWidget):
     def export_definitions(self) -> None:
         try:
             aj.export_definitions(self.flow_data.flow, self)
-        except Exception as e: print(e)
-        # except:
-        #     #! Improve: more specificity
-        #     q.QMessageBox.critical(self, 'Export actor definition data', 'Failed')
+        except:
+            q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + path)
 
     def reload(self) -> None:
         self.view.reload()

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -1,6 +1,7 @@
 import json
 import typing
 
+import eventeditor.actor_json as aj
 from eventeditor.container_model import ContainerModel
 from eventeditor.container_view import ContainerView
 from eventeditor.event_branch_editors import SwitchEventEditDialog, ForkEventEditDialog
@@ -202,6 +203,14 @@ class FlowchartView(q.QWidget):
                 json.dump(data, f, default=lambda x: str(x))
         except:
             q.QMessageBox.critical(self, 'Export graph data', 'Failed to write to ' + path)
+    
+    def export_definitions(self) -> None:
+        try:
+            aj.export_definitions(self.flow_data.flow, self)
+        except Exception as e: print(e)
+        # except:
+        #     #! Improve: more specificity
+        #     q.QMessageBox.critical(self, 'Export actor definition data', 'Failed')
 
     def reload(self) -> None:
         self.view.reload()

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -208,7 +208,7 @@ class FlowchartView(q.QWidget):
         try:
             aj.export_definitions(self.flow_data.flow, self)
         except:
-            q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + path)
+            q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + str(aj._actor_json_path))
 
     def reload(self) -> None:
         self.view.reload()

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -208,7 +208,7 @@ class FlowchartView(q.QWidget):
         try:
             aj.export_definitions(self.flow_data.flow, self)
         except:
-            q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + str(aj._actor_json_path))
+            q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + str(aj._actor_definitions_path))
 
     def reload(self) -> None:
         self.view.reload()


### PR DESCRIPTION
The event editor is compatible with Tears of the Kingdom but the the file structure has changed, meaning that the autofill feature is unusable for it. I've tried to add an alternative option that requires more manual work on the user's part but allows them to setup autofill for Tears of the Kingdom (and potentially other games?). The readme has also been updated with a brief usage guide.

Additionally, this is my first time working with Python, so additional changes may be required (will gladly accept any feedback!)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/event-editor/8)
<!-- Reviewable:end -->
