### PR TITLE
Improve menu bar usability

### DIFF
--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -228,6 +228,7 @@ class MainWindow(q.QMainWindow):
         self.rename_flow_action.setEnabled(bool(self.flow) and bool(self.flow_path))
 
         self.reload_graph_action.setEnabled(bool(self.flow) and bool(self.flow_path))
+        self.export_graph_action.setEnabled(bool(self.flow))
         self.export_definitions_action.setEnabled(bool(self.flow))
         self.add_event_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.add_fork_action.setEnabled(bool(self.flow) and bool(self.flow_path))

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -229,6 +229,7 @@ class MainWindow(q.QMainWindow):
         self.reload_graph_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.save_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.save_as_action.setEnabled(bool(self.flow))
+        self.export_definitions_action.setEnabled(bool(self.flow))
 
     def renameFlow(self) -> None:
         if not self.flow or not self.flow.flowchart:

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -222,14 +222,14 @@ class MainWindow(q.QMainWindow):
             self.setWindowTitle(f'EventEditor - {indicator}{self.flow.name}')
 
         self.open_autosave_action.setEnabled(bool(self.flow) and bool(self.flow_path))
-        self.add_event_action.setEnabled(bool(self.flow) and bool(self.flow_path))
-        self.add_fork_action.setEnabled(bool(self.flow) and bool(self.flow_path))
-        self.event_name_visible_action.setEnabled(bool(self.flow) and bool(self.flow_path))
-        self.rename_flow_action.setEnabled(bool(self.flow) and bool(self.flow_path))
-        self.reload_graph_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.save_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.save_as_action.setEnabled(bool(self.flow))
+        self.rename_flow_action.setEnabled(bool(self.flow) and bool(self.flow_path))
+
+        self.reload_graph_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.export_definitions_action.setEnabled(bool(self.flow))
+        self.add_event_action.setEnabled(bool(self.flow) and bool(self.flow_path))
+        self.add_fork_action.setEnabled(bool(self.flow) and bool(self.flow_path))
 
     def renameFlow(self) -> None:
         if not self.flow or not self.flow.flowchart:

--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -52,43 +52,43 @@ class MainWindow(q.QMainWindow):
             self.readFlow(self.args.event_flow_file)
 
     def initMenu(self) -> None:
+        menu = self.menuBar()
+
+        file_menu = menu.addMenu('&File')
         self.new_action = q.QAction('&New...', self)
         self.new_action.setShortcut(qg.QKeySequence.New)
         self.new_action.triggered.connect(self.onNewFile)
-
+        file_menu.addAction(self.new_action)
         self.open_action = q.QAction('&Open...', self)
         self.open_action.setShortcut(qg.QKeySequence.Open)
         self.open_action.triggered.connect(self.onOpenFile)
-
+        file_menu.addAction(self.open_action)
+        file_menu.addSeparator()
         self.open_autosave_action = q.QAction('Open autosave...', self)
         self.open_autosave_action.triggered.connect(lambda: self.onOpenFile(str(self.flow_data.auto_save.get_directory()), name_filter=f'Flowchart autosave (autosave_{self.flow_data.flow.name}_*.bfevfl.gz)'))
         if not self.flow_data.auto_save.get_directory():
             self.open_autosave_action.setVisible(False)
-
+        file_menu.addAction(self.open_autosave_action)
         self.save_action = q.QAction('&Save', self)
         self.save_action.setShortcut(qg.QKeySequence.Save)
         self.save_action.setEnabled(False)
         self.save_action.triggered.connect(self.onSaveFile)
-
+        file_menu.addAction(self.save_action)
         self.save_as_action = q.QAction('Save as...', self)
         # No shortcut is assigned for Windows in QKeySequence.SaveAs
         # self.save_as_action.setShortcut(qg.QKeySequence.SaveAs)
         self.save_as_action.setShortcut('Ctrl+Shift+S')
         self.save_as_action.setEnabled(False)
         self.save_as_action.triggered.connect(self.onSaveAsFile)
-
+        file_menu.addAction(self.save_as_action)
         self.rename_flow_action = q.QAction('Rename flow', self)
         self.rename_flow_action.triggered.connect(self.renameFlow)
-
+        file_menu.addAction(self.rename_flow_action)
+        file_menu.addSeparator()
         self.exit_action = q.QAction('E&xit', self)
         self.exit_action.setShortcut(qg.QKeySequence.Quit)
         self.exit_action.triggered.connect(self.close)
-
-        menu = self.menuBar()
-
-        file_menu = menu.addMenu('&File')
-        for a in (self.new_action, self.open_action, self.open_autosave_action, self.save_action, self.save_as_action, self.rename_flow_action, self.exit_action):
-            file_menu.addAction(a)
+        file_menu.addAction(self.exit_action)
 
         view_menu = menu.addMenu('Flowc&hart')
         self.event_name_visible_action = q.QAction('&Show event names', self)
@@ -101,6 +101,7 @@ class MainWindow(q.QMainWindow):
         self.event_param_visible_action.setChecked(False)
         self.event_param_visible_action.triggered.connect(self.onEventParamVisibilityChanged)
         view_menu.addAction(self.event_param_visible_action)
+        view_menu.addSeparator()
         self.reload_graph_action = q.QAction('&Reload graph', self)
         self.reload_graph_action.setShortcut('Ctrl+Shift+R')
         view_menu.addAction(self.reload_graph_action)

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -57,11 +57,7 @@ def load_queries(actor_name: str) -> typing.Optional[typing.Iterable[str]]:
     except:
         return None
 
-def export_definitions(flow: typing.Optional[EventFlow], widget: typing.Optional['QWidget']) -> None:
-    if not flow:
-        q.QMessageBox.information(widget, 'Export actor definition data', 'Open an event flow first')
-        return
-
+def export_definitions(flow: EventFlow, widget: typing.Optional['QWidget']) -> None:
     if not _actor_definitions_path:
         set_actor_definitions_path(q.QFileDialog.getSaveFileName(widget, 'Export actor definitions to...',  'actor_definitions', 'JSON (*.json)')[0])
 


### PR DESCRIPTION
Minor menu bar changes to better indicate to the user what actions are possible in the current state (event flow opened or not). Also added separators to group similar actions together.

*Before:*
![ux_before](https://github.com/zeldamods/event-editor/assets/42115696/6adb59dc-3f0b-423b-b1eb-cfac0a5a052a)
*After:*
![ux_after](https://github.com/zeldamods/event-editor/assets/42115696/e33b2127-256f-4e18-829d-1bca87249a3b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/event-editor/10)
<!-- Reviewable:end -->
