### PR TITLE
Add ability to reorder event parameters to defined order

### DIFF
--- a/eventeditor/__main__.py
+++ b/eventeditor/__main__.py
@@ -109,6 +109,8 @@ class MainWindow(q.QMainWindow):
         view_menu.addAction(self.export_graph_action)
         self.export_definitions_action = q.QAction('Ex&port actor definition data to JSON...', self)
         view_menu.addAction(self.export_definitions_action)
+        self.reorder_event_parameters_action = q.QAction('Reorder event parameters', self)
+        view_menu.addAction(self.reorder_event_parameters_action)
         view_menu.addSeparator()
         self.add_event_action = q.QAction('&Add event...', self)
         view_menu.addAction(self.add_event_action)
@@ -157,6 +159,7 @@ class MainWindow(q.QMainWindow):
         self.reload_graph_action.triggered.connect(self.flowchart_view.reload)
         self.export_graph_action.triggered.connect(self.flowchart_view.export)
         self.export_definitions_action.triggered.connect(self.flowchart_view.export_definitions)
+        self.reorder_event_parameters_action.triggered.connect(self.flowchart_view.reorder_event_parameters)
         self.add_event_action.triggered.connect(self.flowchart_view.addNewEvent)
         self.add_fork_action.triggered.connect(self.flowchart_view.addFork)
 
@@ -230,6 +233,7 @@ class MainWindow(q.QMainWindow):
         self.reload_graph_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.export_graph_action.setEnabled(bool(self.flow))
         self.export_definitions_action.setEnabled(bool(self.flow))
+        self.reorder_event_parameters_action.setEnabled(bool(self.flow))
         self.add_event_action.setEnabled(bool(self.flow) and bool(self.flow_path))
         self.add_fork_action.setEnabled(bool(self.flow) and bool(self.flow_path))
 

--- a/eventeditor/actor_json.py
+++ b/eventeditor/actor_json.py
@@ -17,6 +17,13 @@ class EventType(IntEnum):
     Action = 0
     Query = 1
 
+def load_actor_definitions() -> typing.Optional[typing.Dict[str, typing.Any]]:
+    try:
+        with open(_actor_definitions_path, 'rt') as file:
+            return json.loads(file.read())
+    except:
+        return None
+
 def load_actor_json(actor_name: str) -> typing.Optional[typing.Dict[str, typing.Any]]:
     if not _actor_definitions_path:
         return None
@@ -64,11 +71,7 @@ def export_definitions(flow: EventFlow, widget: typing.Optional['QWidget']) -> N
     if not _actor_definitions_path:
         return
 
-    try:
-        with open(_actor_definitions_path, 'rt') as file:
-            definitions = json.loads(file.read())
-    except:
-        definitions = dict()
+    definitions = load_actor_definitions() or dict()
 
     for actor in flow.flowchart.actors:
         actor_root = definitions.get(actor.identifier.name, {})

--- a/eventeditor/container_view.py
+++ b/eventeditor/container_view.py
@@ -145,6 +145,7 @@ class ContainerAddItemDialog(q.QDialog):
 
 class ContainerView(q.QWidget):
     autofillRequested = qc.pyqtSignal()
+    reorderRequested = qc.pyqtSignal()
     copyJsonRequested = qc.pyqtSignal()
     pasteJsonRequested = qc.pyqtSignal()
 
@@ -176,6 +177,9 @@ class ContainerView(q.QWidget):
         self.autofill_btn = q.QPushButton('Auto fill')
         self.autofill_btn.setStyleSheet('padding: 2px 5px;')
         self.autofill_btn.clicked.connect(self.autofillRequested)
+        self.reorder_btn = q.QPushButton('Reorder')
+        self.reorder_btn.setStyleSheet('padding: 2px 5px;')
+        self.reorder_btn.clicked.connect(self.reorderRequested)
         self.copy_btn = q.QPushButton('Copy JSON')
         self.copy_btn.setStyleSheet('padding: 2px 5px;')
         self.copy_btn.clicked.connect(self.copyJsonRequested)
@@ -189,6 +193,7 @@ class ContainerView(q.QWidget):
         if has_autofill_btn:
             box.addWidget(self.copy_btn)
             box.addWidget(self.paste_btn)
+            box.addWidget(self.reorder_btn)
             box.addWidget(self.autofill_btn)
         box.addWidget(self.add_btn)
 

--- a/eventeditor/flowchart_tools.py
+++ b/eventeditor/flowchart_tools.py
@@ -15,12 +15,15 @@ def reorder_event_flow_parameters(flow: EventFlow) -> None:
         else:
             continue
 
+        if not event.data.params:
+            continue
+
         if not definition:
-            if isinstance(event.data, ActionEvent):
-                event_type = event.data.actor_action.v.v
-            elif isinstance(event.data, SwitchEvent):
-                event_type = event.data.actor_query.v.v
-            print(f' > ndef: {event.data.actor.v.identifier.name}::{event_type} ({event.name})')
+            # if isinstance(event.data, ActionEvent):
+            #     event_type = event.data.actor_action.v.v
+            # elif isinstance(event.data, SwitchEvent):
+            #     event_type = event.data.actor_query.v.v
+            # print(f' > ndef: {event.data.actor.v.identifier.name}::{event_type} ({event.name})')
             continue
 
         reorder_event_parameters(event.data.params.data, definition)

--- a/eventeditor/flowchart_tools.py
+++ b/eventeditor/flowchart_tools.py
@@ -15,15 +15,12 @@ def reorder_event_flow_parameters(flow: EventFlow) -> None:
         else:
             continue
 
+        # Nothing to sort
         if not event.data.params:
             continue
 
+        # No defined order to sort by
         if not definition:
-            # if isinstance(event.data, ActionEvent):
-            #     event_type = event.data.actor_action.v.v
-            # elif isinstance(event.data, SwitchEvent):
-            #     event_type = event.data.actor_query.v.v
-            # print(f' > ndef: {event.data.actor.v.identifier.name}::{event_type} ({event.name})')
             continue
 
         reorder_event_parameters(event.data.params.data, definition)

--- a/eventeditor/flowchart_tools.py
+++ b/eventeditor/flowchart_tools.py
@@ -1,0 +1,30 @@
+import json
+import typing
+
+from evfl import EventFlow
+from evfl.event import ActionEvent, SwitchEvent
+
+def reorder_event_flow_parameters(flow: EventFlow, definitions: typing.Dict[str, typing.Any]) -> None:
+    for event in flow.flowchart.events:
+        if isinstance(event.data, ActionEvent):
+            definition = definitions[event.data.actor.v.identifier.name]['actions'][event.data.actor_action.v.v].keys()
+        elif isinstance(event.data, SwitchEvent):
+            definition = definitions[event.data.actor.v.identifier.name]['queries'][event.data.actor_query.v.v].keys()
+        else:
+            continue
+
+        if not definition:
+            if isinstance(event.data, ActionEvent):
+                event_type = event.data.actor_action.v.v
+            elif isinstance(event.data, SwitchEvent):
+                event_type = event.data.actor_query.v.v
+            print(f' > {event.data.actor.v.identifier.name}::{event.name} ({event_type})')
+            continue
+
+        reorder_event_parameters(event.data.params.data, definition)
+
+# Parameters not contained in the definition will be left at the start of the collection
+def reorder_event_parameters(params: typing.Dict[str, typing.Any], definition: typing.Iterable[str]) -> None:
+    for param in definition:
+        if param in params:
+            params[param] = params.pop(param)

--- a/eventeditor/flowchart_tools.py
+++ b/eventeditor/flowchart_tools.py
@@ -1,15 +1,17 @@
-import json
 import typing
 
+import eventeditor.actor_json as aj
 from evfl import EventFlow
 from evfl.event import ActionEvent, SwitchEvent
 
-def reorder_event_flow_parameters(flow: EventFlow, definitions: typing.Dict[str, typing.Any]) -> None:
+def reorder_event_flow_parameters(flow: EventFlow) -> None:
+    # Should probably cache definition loads, though
+    # current is useful for ensuring latest file version
     for event in flow.flowchart.events:
         if isinstance(event.data, ActionEvent):
-            definition = definitions[event.data.actor.v.identifier.name]['actions'][event.data.actor_action.v.v].keys()
+            definition = aj.load_event_parameters(event.data.actor.v.identifier.name, event.data.actor_action.v.v, aj.EventType.Action)
         elif isinstance(event.data, SwitchEvent):
-            definition = definitions[event.data.actor.v.identifier.name]['queries'][event.data.actor_query.v.v].keys()
+            definition = aj.load_event_parameters(event.data.actor.v.identifier.name, event.data.actor_query.v.v, aj.EventType.Query)
         else:
             continue
 
@@ -18,7 +20,7 @@ def reorder_event_flow_parameters(flow: EventFlow, definitions: typing.Dict[str,
                 event_type = event.data.actor_action.v.v
             elif isinstance(event.data, SwitchEvent):
                 event_type = event.data.actor_query.v.v
-            print(f' > {event.data.actor.v.identifier.name}::{event.name} ({event_type})')
+            print(f' > ndef: {event.data.actor.v.identifier.name}::{event_type} ({event.name})')
             continue
 
         reorder_event_parameters(event.data.params.data, definition)

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -9,6 +9,7 @@ from eventeditor.event_edit_dialog import show_event_editor
 from eventeditor.event_chooser_dialog import show_event_type_chooser, add_new_event, EventChooserDialog, CheckableEventParentListWidget
 from eventeditor.event_fork_chooser_dialog import EventForkChooserDialog
 from eventeditor.flow_data import FlowData, FlowDataChangeReason
+import eventeditor.flowchart_tools as ft
 from eventeditor.search_bar import SearchBar
 from eventeditor.util import *
 from evfl import Container, Flowchart, Actor, Event, EventFlow, ActionEvent, SwitchEvent, ForkEvent, JoinEvent, SubFlowEvent
@@ -209,6 +210,18 @@ class FlowchartView(q.QWidget):
             aj.export_definitions(self.flow_data.flow, self)
         except:
             q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + str(aj._actor_definitions_path))
+    
+    def reorder_event_parameters(self) -> None:
+        try:
+            definitions = aj.load_actor_definitions()
+            if not definitions:
+                q.QMessageBox.critical(self, 'Reorder event parameters', 'Failed to load actor definitions')
+                return
+
+            ft.reorder_event_flow_parameters(self.flow_data.flow, definitions)
+            self.flow_data.flowDataChanged.emit(FlowDataChangeReason.EventParameters)
+        except Exception as e:
+            print(e)
 
     def reload(self) -> None:
         self.view.reload()

--- a/eventeditor/flowchart_view.py
+++ b/eventeditor/flowchart_view.py
@@ -212,16 +212,8 @@ class FlowchartView(q.QWidget):
             q.QMessageBox.critical(self, 'Export actor definition data', 'Failed to write to ' + str(aj._actor_definitions_path))
     
     def reorder_event_parameters(self) -> None:
-        try:
-            definitions = aj.load_actor_definitions()
-            if not definitions:
-                q.QMessageBox.critical(self, 'Reorder event parameters', 'Failed to load actor definitions')
-                return
-
-            ft.reorder_event_flow_parameters(self.flow_data.flow, definitions)
-            self.flow_data.flowDataChanged.emit(FlowDataChangeReason.EventParameters)
-        except Exception as e:
-            print(e)
+        ft.reorder_event_flow_parameters(self.flow_data.flow)
+        self.flow_data.flowDataChanged.emit(FlowDataChangeReason.EventParameters)
 
     def reload(self) -> None:
         self.view.reload()


### PR DESCRIPTION
Event parameters in extracted event flows don't necessarily follow a consistent order, but the ordering of event parameters is persistent.

The ability to reorder these parameters *(in the order defined in the actor definition(s) file)* allows for easier comparison of event parameters when editing or creating event flows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/event-editor/11)
<!-- Reviewable:end -->
